### PR TITLE
Fix memory leak caused by not freeing cusparse info and desc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 scenes/*
 output/*
 *.ipynb_checkpoints*
-
+build
+*.egg-info

--- a/largesteps/parameterize.py
+++ b/largesteps/parameterize.py
@@ -29,7 +29,7 @@ def to_differential(L, v):
     """
     return L @ v
 
-def from_differential(L, u, method='Cholesky'):
+def from_differential(L, u, method='Cholesky', num_right_hand_size=3):
     """
     Convert differential coordinates back to Cartesian.
 
@@ -45,10 +45,10 @@ def from_differential(L, u, method='Cholesky'):
     method : {'Cholesky', 'CG'}
         Solver to use.
     """
-    key = (id(L), method)
+    key = (id(L), method, num_right_hand_size)
     if key not in _cache.keys():
         if method == 'Cholesky':
-            solver = CholeskySolver(L)
+            solver = CholeskySolver(L, num_right_hand_size)
         elif method == 'CG':
             solver = ConjugateGradientSolver(L)
         else:

--- a/largesteps/solvers.py
+++ b/largesteps/solvers.py
@@ -11,6 +11,11 @@ from cupy._core.dlpack import fromDlpack
 from torch.utils.dlpack import to_dlpack
 from torch.utils.dlpack import from_dlpack
 
+import cupy as _cupy
+from cupy.cuda import device as _device
+from cupy_backends.cuda.libs import cusparse as _cusparse
+import cupyx.scipy.sparse
+
 def torch_to_cupy(x):
     """
     Convert a PyTorch tensor to a CuPy array.
@@ -22,61 +27,6 @@ def cupy_to_torch(x):
     Convert a CuPy array to a PyTorch tensor.
     """
     return from_dlpack(toDlpack(x))
-
-def prepare(A, transpose, blocking=True, level_info=True):
-    import cupy as _cupy
-    from cupy.cuda import device as _device
-    from cupy_backends.cuda.libs import cusparse as _cusparse
-    import cupyx.scipy.sparse
-
-    policy = _cusparse.CUSPARSE_SOLVE_POLICY_USE_LEVEL if level_info \
-        else _cusparse.CUSPARSE_SOLVE_POLICY_NO_LEVEL
-    algo = 1 if blocking else 0
-
-    transa = _cusparse.CUSPARSE_OPERATION_TRANSPOSE if transpose \
-        else _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
-    transb = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
-    fill_mode = _cusparse.CUSPARSE_FILL_MODE_LOWER
-
-    if cupyx.scipy.sparse.isspmatrix_csc(A):
-        A = A.T
-        transa = 1 - transa
-        fill_mode = 1 - fill_mode
-
-    assert cupyx.scipy.sparse.isspmatrix_csr(A)
-
-    handle = _device.get_cusparse_handle()
-    info = _cusparse.createCsrsm2Info()
-    m = A.shape[0]
-    alpha = np.array(1, dtype=np.float32)
-    desc = _cusparse.createMatDescr()
-    _cusparse.setMatType(desc, _cusparse.CUSPARSE_MATRIX_TYPE_GENERAL)
-    _cusparse.setMatIndexBase(desc, _cusparse.CUSPARSE_INDEX_BASE_ZERO)
-    _cusparse.setMatFillMode(desc, fill_mode)
-    _cusparse.setMatDiagType(desc, _cusparse.CUSPARSE_DIAG_TYPE_NON_UNIT)
-
-    nrhs = 3
-    ldb = nrhs
-
-    ws_size = _cusparse.scsrsm2_bufferSizeExt(
-        handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
-        desc, A.data.data.ptr, A.indptr.data.ptr, A.indices.data.ptr,
-        0, ldb, info, policy)
-
-    ws = _cupy.empty((ws_size,), dtype=np.int8)
-
-    _cusparse.scsrsm2_analysis(
-         handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
-         desc, A.data.data.ptr, A.indptr.data.ptr,
-         A.indices.data.ptr, 0, ldb, info, policy, ws.data.ptr)
-
-    def solver(b):
-        _cusparse.scsrsm2_solve(
-            handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
-            desc, A.data.data.ptr, A.indptr.data.ptr, A.indices.data.ptr,
-            b.data.ptr, ldb, info, policy, ws.data.ptr)
-
-    return solver
 
 class Solver:
     """
@@ -105,6 +55,68 @@ class CholeskySolver(Solver):
     Precomputes the Cholesky decomposition of the system matrix and solves the
     system by back-substitution.
     """
+
+    def __del__(self):
+        if hasattr(self, 'infos'):
+            for info in self.infos:
+                _cusparse.destroyCsrsm2Info(info)
+        if hasattr(self, 'descs'):
+            for desc in self.descs:
+                _cusparse.destroyMatDescr(desc)
+
+
+    def prepare(self, A, transpose, blocking=True, level_info=True):
+        policy = _cusparse.CUSPARSE_SOLVE_POLICY_USE_LEVEL if level_info \
+            else _cusparse.CUSPARSE_SOLVE_POLICY_NO_LEVEL
+        algo = 1 if blocking else 0
+
+        transa = _cusparse.CUSPARSE_OPERATION_TRANSPOSE if transpose \
+            else _cusparse.CUSPARSE_OPERATION_NON_TRANSPOSE
+        transb = _cusparse.CUSPARSE_OPERATION_TRANSPOSE
+        fill_mode = _cusparse.CUSPARSE_FILL_MODE_LOWER
+
+        if cupyx.scipy.sparse.isspmatrix_csc(A):
+            A = A.T
+            transa = 1 - transa
+            fill_mode = 1 - fill_mode
+
+        assert cupyx.scipy.sparse.isspmatrix_csr(A)
+
+        handle = _device.get_cusparse_handle()
+        info = _cusparse.createCsrsm2Info()
+        self.infos.append(info) # will cause memory leak if not freed manully
+        m = A.shape[0]
+        alpha = np.array(1, dtype=np.float32)
+        desc = _cusparse.createMatDescr()
+        self.descs.append(desc) # will cause memory leak if not freed manully
+        _cusparse.setMatType(desc, _cusparse.CUSPARSE_MATRIX_TYPE_GENERAL)
+        _cusparse.setMatIndexBase(desc, _cusparse.CUSPARSE_INDEX_BASE_ZERO)
+        _cusparse.setMatFillMode(desc, fill_mode)
+        _cusparse.setMatDiagType(desc, _cusparse.CUSPARSE_DIAG_TYPE_NON_UNIT)
+
+        nrhs = 3
+        ldb = nrhs
+
+        ws_size = _cusparse.scsrsm2_bufferSizeExt(
+            handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
+            desc, A.data.data.ptr, A.indptr.data.ptr, A.indices.data.ptr,
+            0, ldb, info, policy)
+
+        ws = _cupy.empty((ws_size,), dtype=np.int8)
+
+        _cusparse.scsrsm2_analysis(
+            handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
+            desc, A.data.data.ptr, A.indptr.data.ptr,
+            A.indices.data.ptr, 0, ldb, info, policy, ws.data.ptr)
+
+        def solver(b):
+            _cusparse.scsrsm2_solve(
+                handle, algo, transa, transb, m, nrhs, A.nnz, alpha.ctypes.data,
+                desc, A.data.data.ptr, A.indptr.data.ptr, A.indices.data.ptr,
+                b.data.ptr, ldb, info, policy, ws.data.ptr)
+
+        return solver
+
     def __init__(self, M):
         """
         Initialize the solver
@@ -127,8 +139,10 @@ class CholeskySolver(Solver):
         self.U = self.L.T
         self.P = cp.array(P)
         self.Pi = cp.array(Pi)
-        self.solver_1 = prepare(self.L, False, False, True)
-        self.solver_2 = prepare(self.L, True, False, True)
+        self.infos = [] # cusparse allocation records (needs manual freeing in __del__)
+        self.descs = [] # cusparse allocation records (needs manual freeing in __del__)
+        self.solver_1 = self.prepare(self.L, False, False, True)
+        self.solver_2 = self.prepare(self.L, True, False, True)
 
     def solve(self, b, backward=False):
         """

--- a/largesteps/solvers.py
+++ b/largesteps/solvers.py
@@ -65,7 +65,7 @@ class CholeskySolver(Solver):
                 _cusparse.destroyMatDescr(desc)
 
 
-    def prepare(self, A, transpose, blocking=True, level_info=True):
+    def prepare(self, A, transpose, blocking=True, level_info=True, nrhs=3):
         policy = _cusparse.CUSPARSE_SOLVE_POLICY_USE_LEVEL if level_info \
             else _cusparse.CUSPARSE_SOLVE_POLICY_NO_LEVEL
         algo = 1 if blocking else 0
@@ -94,7 +94,6 @@ class CholeskySolver(Solver):
         _cusparse.setMatFillMode(desc, fill_mode)
         _cusparse.setMatDiagType(desc, _cusparse.CUSPARSE_DIAG_TYPE_NON_UNIT)
 
-        nrhs = 3
         ldb = nrhs
 
         ws_size = _cusparse.scsrsm2_bufferSizeExt(
@@ -117,7 +116,7 @@ class CholeskySolver(Solver):
 
         return solver
 
-    def __init__(self, M):
+    def __init__(self, M, nrhs=3):
         """
         Initialize the solver
 
@@ -141,8 +140,8 @@ class CholeskySolver(Solver):
         self.Pi = cp.array(Pi)
         self.infos = [] # cusparse allocation records (needs manual freeing in __del__)
         self.descs = [] # cusparse allocation records (needs manual freeing in __del__)
-        self.solver_1 = self.prepare(self.L, False, False, True)
-        self.solver_2 = self.prepare(self.L, True, False, True)
+        self.solver_1 = self.prepare(self.L, False, False, True, nrhs)
+        self.solver_2 = self.prepare(self.L, True, False, True, nrhs)
 
     def solve(self, b, backward=False):
         """


### PR DESCRIPTION
#6 fix:
The memory leak is actually caused by not calling corresponding destroy methods after creating csrsm2info by `_cusparse.createCsrsm2Info()` and creating matdescr by `_cusparse.createMatDescr`. Adding corresponding `_cusparse.destroyCsrsm2Info` and `_cusparse.destroyMatDescr` in the `__del__` method of `CholeskySolver` will resolve the issue.

Reference:
https://docs.nvidia.com/cuda/cusparse/index.html#cusparseDestroyMatDescr
https://docs.nvidia.com/cuda/cusparse/index.html#cusparseDestroyCsrsm2Info